### PR TITLE
Fixed invalid JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redis-viewer",
   "author": "Jim Fleming <jim@freeflow.io> (http://freeflow.io/)",
-  "url": "https://github.com/FreeFlow/redis-viewer"
+  "url": "https://github.com/FreeFlow/redis-viewer",
   "description": "A simple browser-based admin for redis",
   "version": "0.5.0",
   "repository": {
@@ -9,13 +9,13 @@
     "url": "git://github.com/FreeFlow/redis-viewer.git"
   },
   "dependencies": {
-    "coffee-script": "1.1"
-    "less": "1"
-    "express": "2"
-    "socket.io": "0.6"
-    "underscore": "1"
-    "optimist": "0.1"
-    "redis": "0.6"
+    "coffee-script": "1.1",
+    "less": "1",
+    "express": "2",
+    "socket.io": "0.6",
+    "underscore": "1",
+    "optimist": "0.1",
+    "redis": "0.6",
     "hiredis": "0.1"
   }
 }


### PR DESCRIPTION
``` bash
$ git clone
```

failed with 

``` bash
$ npm install
```

since the package.json was invalid.
